### PR TITLE
Re-enabled boom.dm

### DIFF
--- a/console.dme
+++ b/console.dme
@@ -16,6 +16,7 @@
 #include "code\changelog\changes.dm"
 #include "code\client\client.dm"
 #include "code\client\zooming.dm"
+#include "code\effect\boom.dm"
 #include "code\hardware\antenna.dm"
 #include "code\hardware\bounce.dm"
 #include "code\hardware\computer.dm"


### PR DESCRIPTION
I don't know why this was disabled, but it happened in the books commit.